### PR TITLE
fix: In Latest version of Vite, OutDir is already relative to root in…

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "cesium": "^1.85.0",
-    "vite": "^2.5.6",
+    "vite": "^2.7.1",
     "vite-plugin-cesium": "^1.2.10"
   }
 }

--- a/demo/vite.config.js
+++ b/demo/vite.config.js
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
-import cesium from 'vite-plugin-cesium';
+import cesium from '../src/index.ts';
 export default defineConfig({
   plugins: [cesium()]
 });

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/serve-static": "^1.13.9",
     "prettier": "^2.2.1",
     "typescript": "^4.2.2",
-    "vite": "^2.5.6"
+    "vite": "^2.7.1"
   },
   "peerDependencies": {
     "cesium": "^1.85.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,10 +56,6 @@ function vitePluginCesium(
       return userConfig;
     },
 
-    configResolved(resolvedConfig) {
-      outDir = path.join(resolvedConfig.root, resolvedConfig.build.outDir);
-    },
-
     async load(id: string) {
       if (!rebuildCesium) return null;
       // replace CESIUM_BASE_URL variable in 'cesium/Source/Core/buildModuleUrl.js'


### PR DESCRIPTION
在最新版本的vite中，resolvedConfig.build.outDir已经是基于当前root的输出路径了