### PR TITLE
fix relative path problem

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,21 +116,26 @@ function vitePluginCesium(
     },
 
     transformIndexHtml() {
+      // Compatible with relative and absolute paths
+      const fixBase = (href: string) => {
+        return href.indexOf('/') === 0 ? href : (base+href);
+      }
+      
       const tags: HtmlTagDescriptor[] = [
         {
           tag: 'link',
           attrs: {
             rel: 'stylesheet',
-            href: normalizePath(
+            href: fixBase(normalizePath(
               path.join(CESIUM_BASE_URL, 'Widgets/widgets.css')
-            )
+            ))
           }
         }
       ];
       if (isBuild && !rebuildCesium) {
         tags.push({
           tag: 'script',
-          attrs: { src: normalizePath(path.join(base, 'cesium/Cesium.js')) }
+          attrs: { src: fixBase(normalizePath(path.join(base, 'cesium/Cesium.js'))) }
         });
       }
       return tags;


### PR DESCRIPTION
I want to configure the base property to './', but I found that using this plugin will cause cesium loading errors in development mode; after packaging, the links in the index.html file also have problems.

![image](https://user-images.githubusercontent.com/21308368/156320614-4b2d9639-c81e-42fc-b1cb-74cbacbbec7b.png)

after build
![image](https://user-images.githubusercontent.com/21308368/156321368-9eeea730-b008-4877-a1ba-7916ee14178c.png)

So I added some code to fix this.
