### PR TITLE
fix: tags respect base path

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 semi: true
 tabWidth: 2
 singleQuote: true
-printWidth: 80
+printWidth: 120
 trailingComma: none

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,37 +77,19 @@ function vitePluginCesium(
     },
 
     configureServer({ middlewares }) {
-      const cesiumPath = path.join(
-        cesiumBuildRootPath,
-        devMinifyCesium ? 'Cesium' : 'CesiumUnminified'
-      );
+      const cesiumPath = path.join(cesiumBuildRootPath, devMinifyCesium ? 'Cesium' : 'CesiumUnminified');
       middlewares.use(CESIUM_BASE_URL, serveStatic(cesiumPath));
     },
 
     async closeBundle() {
       if (isBuild) {
         try {
-          await fs.copy(
-            path.join(cesiumBuildPath, 'Assets'),
-            path.join(outDir, 'cesium/Assets')
-          );
-          await fs.copy(
-            path.join(cesiumBuildPath, 'ThirdParty'),
-            path.join(outDir, 'cesium/ThirdParty')
-          );
-          await fs.copy(
-            path.join(cesiumBuildPath, 'Workers'),
-            path.join(outDir, 'cesium/Workers')
-          );
-          await fs.copy(
-            path.join(cesiumBuildPath, 'Widgets'),
-            path.join(outDir, 'cesium/Widgets')
-          );
+          await fs.copy(path.join(cesiumBuildPath, 'Assets'), path.join(outDir, 'cesium/Assets'));
+          await fs.copy(path.join(cesiumBuildPath, 'ThirdParty'), path.join(outDir, 'cesium/ThirdParty'));
+          await fs.copy(path.join(cesiumBuildPath, 'Workers'), path.join(outDir, 'cesium/Workers'));
+          await fs.copy(path.join(cesiumBuildPath, 'Widgets'), path.join(outDir, 'cesium/Widgets'));
           if (!rebuildCesium) {
-            await fs.copy(
-              path.join(cesiumBuildPath, 'Cesium.js'),
-              path.join(outDir, 'cesium/Cesium.js')
-            );
+            await fs.copy(path.join(cesiumBuildPath, 'Cesium.js'), path.join(outDir, 'cesium/Cesium.js'));
           }
         } catch (err) {
           console.error('copy failed', err);
@@ -121,9 +103,7 @@ function vitePluginCesium(
           tag: 'link',
           attrs: {
             rel: 'stylesheet',
-            href:
-              base +
-              normalizePath(path.join(CESIUM_BASE_URL, 'Widgets/widgets.css'))
+            href: base + normalizePath(path.join(CESIUM_BASE_URL, 'Widgets/widgets.css'))
           }
         }
       ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,16 +121,18 @@ function vitePluginCesium(
           tag: 'link',
           attrs: {
             rel: 'stylesheet',
-            href: normalizePath(
-              path.join(CESIUM_BASE_URL, 'Widgets/widgets.css')
-            )
+            href:
+              base +
+              normalizePath(path.join(CESIUM_BASE_URL, 'Widgets/widgets.css'))
           }
         }
       ];
       if (isBuild && !rebuildCesium) {
         tags.push({
           tag: 'script',
-          attrs: { src: normalizePath(path.join(base, 'cesium/Cesium.js')) }
+          attrs: {
+            src: base + normalizePath(path.join(CESIUM_BASE_URL, 'Cesium.js'))
+          }
         });
       }
       return tags;


### PR DESCRIPTION
vite.config.ts
```typescript
import { defineConfig } from 'vite';
import cesium from 'vite-plugin-cesium';
export default defineConfig({
  base:'./',
  plugins: [cesium()]
});

```
This pr previous build result , `demo/dist/index.html`.
```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <link rel="stylesheet" href="cesium/Widgets/widgets.css">
    <script src="cesium/Cesium.js"></script>

    <meta charset="UTF-8" />
    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>cesium-vite</title>
    
    <script type="module" crossorigin src="./assets/index.1cfdf679.js"></script>
    <link rel="stylesheet" href="./assets/index.007faab3.css">
  </head>

  <body>
    <div id="cesiumContainer"></div>
  </body>
</html>

```
The build result after this pr , `demo/dist/index.html`.
```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <link rel="stylesheet" href="./cesium/Widgets/widgets.css">
    <script src="./cesium/Cesium.js"></script>

    <meta charset="UTF-8" />
    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>cesium-vite</title>
    
    <script type="module" crossorigin src="./assets/index.1cfdf679.js"></script>
    <link rel="stylesheet" href="./assets/index.007faab3.css">
  </head>

  <body>
    <div id="cesiumContainer"></div>
  </body>
</html>
```

