### PR TITLE
Configurable parameters for build path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,15 +14,13 @@ interface VitePluginCesiumOptions {
   cesiumBuildPath?: string
 }
 
-function vitePluginCesium(
-  options: VitePluginCesiumOptions = {
-    rebuildCesium: false,
-    devMinifyCesium: false,
-    cesiumBuildRootPath: 'node_modules/cesium/Build',
-    cesiumBuildPath: 'node_modules/cesium/Build/Cesium/'
-  }
-): Plugin {
-  const { rebuildCesium, devMinifyCesium, cesiumBuildRootPath, cesiumBuildPath } = options;
+function vitePluginCesium(options: VitePluginCesiumOptions): Plugin {
+  const { 
+    rebuildCesium = false, 
+    devMinifyCesium = false, 
+    cesiumBuildRootPath = 'node_modules/cesium/Build', 
+    cesiumBuildPath = 'node_modules/cesium/Build/Cesium/' 
+  } = options;
 
   let CESIUM_BASE_URL = 'cesium/';
   let outDir = 'dist';

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ interface VitePluginCesiumOptions {
   cesiumBuildPath?: string
 }
 
-function vitePluginCesium(options: VitePluginCesiumOptions): Plugin {
+function vitePluginCesium(options: VitePluginCesiumOptions = {}): Plugin {
   const { 
     rebuildCesium = false, 
     devMinifyCesium = false, 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,18 +10,19 @@ interface VitePluginCesiumOptions {
    */
   rebuildCesium?: boolean;
   devMinifyCesium?: boolean;
+  cesiumBuildRootPath?: string;
+  cesiumBuildPath?: string
 }
 
 function vitePluginCesium(
   options: VitePluginCesiumOptions = {
     rebuildCesium: false,
-    devMinifyCesium: false
+    devMinifyCesium: false,
+    cesiumBuildRootPath: 'node_modules/cesium/Build',
+    cesiumBuildPath: 'node_modules/cesium/Build/Cesium/'
   }
 ): Plugin {
-  const { rebuildCesium, devMinifyCesium } = options;
-
-  const cesiumBuildRootPath = 'node_modules/cesium/Build';
-  const cesiumBuildPath = 'node_modules/cesium/Build/Cesium/';
+  const { rebuildCesium, devMinifyCesium, cesiumBuildRootPath, cesiumBuildPath } = options;
 
   let CESIUM_BASE_URL = 'cesium/';
   let outDir = 'dist';


### PR DESCRIPTION
This enables to configure the path for where the cesium build is.

Needed for when using the Cesium Ion SDK locally.