### PR TITLE
fix: vite root directory not taken into account when set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,11 @@ export default function vitePluginCesium(options: VitePluginCesiumOptions = {}):
         if (base === '') base = './';
       }
       if (c.build?.outDir) {
-        outDir = c.build.outDir;
+        if (c.root !== undefined) {
+          outDir = path.join(c.root, c.build.outDir);
+        } else {
+          outDir = c.build.outDir;
+        }
       }
       CESIUM_BASE_URL = path.posix.join(base, CESIUM_BASE_URL);
       const userConfig: UserConfig = {};


### PR DESCRIPTION
Allows using a different vite root directory than the default one