### PR TITLE
Revert "fix: vite root directory not taken into account when set"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,11 +42,7 @@ export default function vitePluginCesium(options: VitePluginCesiumOptions = {}):
         if (base === '') base = './';
       }
       if (c.build?.outDir) {
-        if (c.root !== undefined) {
-          outDir = path.join(c.root, c.build.outDir);
-        } else {
-          outDir = c.build.outDir;
-        }
+        outDir = c.build.outDir;
       }
       CESIUM_BASE_URL = path.posix.join(base, CESIUM_BASE_URL);
       const userConfig: UserConfig = {};


### PR DESCRIPTION
I believe [this PR](https://github.com/nshen/vite-plugin-cesium/pull/46) was merged in error. The `outDir` and `root` options are 2 separate things in vite, one should not be used to compute the other.

This caused a bug in our build pipeline
- vite root is `/Users/yannick/project/src`
- outDir is `/Users/yannick/project/dist`

With this change, the cesium files are now generated in `/Users/yannick/project/src/Users/yannick/project/dist/cesium`. But both root and outDir options are correctly configured.

@jfayot it doesn't look like this plugin was using the root folder of the project at all before, so I don't understand how using a different `root` than the default would break this plugin. But if you can provide more details I'd be happy to look into it!